### PR TITLE
JsonRpcSharp.TcpClient: pin FSharp.Core version

### DIFF
--- a/src/JsonRpcSharp.TcpClient/JsonRpcSharp.TcpClient.fsproj
+++ b/src/JsonRpcSharp.TcpClient/JsonRpcSharp.TcpClient.fsproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit pins the FSharp.Core version to 4.7.0.0 to prevent conflict in geewallet.