### PR TITLE
TcpClient: upgrade System.IO.Pipelines

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build_and_deploy:
     env:
-      BASE_VERSION: 0.98.0
+      BASE_VERSION: 0.99.0
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1

--- a/JsonRpcSharp.nuspec
+++ b/JsonRpcSharp.nuspec
@@ -21,7 +21,7 @@
         <dependencies>
             <group targetFramework="netstandard2.0">
                 <dependency id="Common.Logging.Core" version="3.4.1" exclude="Build,Analyzers" />
-                <dependency id="System.IO.Pipelines" version="4.5.3" exclude="Build,Analyzers" />
+                <dependency id="System.IO.Pipelines" version="8.0.0" exclude="Build,Analyzers" />
             </group>
         </dependencies>
     </metadata>

--- a/src/JsonRpcSharp.TcpClient/JsonRpcSharp.TcpClient.fsproj
+++ b/src/JsonRpcSharp.TcpClient/JsonRpcSharp.TcpClient.fsproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hopefully it fixes this weird bug:
https://github.com/nblockchain/geewallet/issues/258

Transitive dependencies of S.IO.P. also got upgraded:
* System.Buffers -> 4.5.1
* System.Memory -> 4.5.5
* System.Threading.Tasks.Extensions -> 4.5.4

And this update might need an assembly redirect like this:
```
            <dependentAssembly>
                <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
            </dependentAssembly>
```

Which was extracted from:
https://github.com/nblockchain/geewallet/pull/252/files